### PR TITLE
Icon fix for some Help Icons from Plugins & more

### DIFF
--- a/less/functions.less
+++ b/less/functions.less
@@ -15,6 +15,7 @@
   height: 0 !important;
   width: 0 !important;
   background-size: 100% 100% !important;
+  font-size: 0px !important;
 }
 
 @-webkit-keyframes rotating {

--- a/less/images.less
+++ b/less/images.less
@@ -187,9 +187,24 @@
 [src$='credentials.png'] {
   .icon(@size-xl);
   .icon-img('../images/key.svg', @color-grey);
-  &[style^="width: 24px"] {
+  &[style^="width: 24px"], &[width^="24"] {
     .icon(@size-md);
   }
+}
+
+[src$='user.png'][width^="24"] {
+  .icon(@size-md);
+  .icon-img('../images/ic_people_black.svg', @color-grey);
+}
+
+[src$='notepad.png'][width^="24"] {
+  .icon(@size-md);
+  .icon-img('../images/ic_history_black.svg', @color-grey);
+}
+
+[src$='setting.png'][width^="24"] {
+  .icon(@size-md);
+  .icon-img('../images/ic_settings_black.svg', @color-grey);
 }
 
 [src$='domain.png'] {

--- a/less/style.less
+++ b/less/style.less
@@ -62,7 +62,6 @@ a, a:hover, a:visited, a:link {
   right: 0;
   left: 0;
   top: 0;
-  z-index: 1030;
   letter-spacing: 1px;
   padding: 12px 10px;
 
@@ -86,7 +85,8 @@ a, a:hover, a:visited, a:link {
 }
 
 #breadcrumbBar {
-  background-color: transparent
+  background-color: transparent;
+  visibility: hidden
 }
 
 .top-sticker-inner {


### PR DESCRIPTION
HI @afonsof 
i like your Jenkins Theme with the icons,

i found a bug with a plugin and the help icons.

Its the ``alt``-text it appears if the help icon has no ``src`` in the ``img``-tag

Example from Violations Plugin: 
![Violations Plugin Example](https://cloud.githubusercontent.com/assets/1554582/12526125/714a856a-c16a-11e5-8484-edd710cb5837.png)