### PR TITLE
Bring back "Back to Dashboard link"

### DIFF
--- a/less/style.less
+++ b/less/style.less
@@ -31,16 +31,15 @@ a, a:hover, a:visited, a:link {
 }
 
 .task-link[href='/'] {
-  display: none;
+  display: inline;
 }
 
 .task-icon-link[href='/'] {
-  position: fixed;
-  top: 12px;
-  left: 20px;
+  position: relative;
+  display: inline-block;
   background-color: @color-link;
   height: 40px;
-  width: 170px;
+  width: auto;
   z-index: 1100;
 
   &:hover {


### PR DESCRIPTION
Not sure if this was intentional but it looked kind of odd to me. 

**before:**

![image](https://cloud.githubusercontent.com/assets/781818/12615683/1fbe8c50-c4d5-11e5-9653-6878f099f12a.png)

---

**after:**

![image](https://cloud.githubusercontent.com/assets/781818/12615684/25eb2110-c4d5-11e5-8bc5-d2d022ade930.png)


