### PR TITLE
Fix #25: missing icon override on the Build Time Trend page

### DIFF
--- a/less/images.less
+++ b/less/images.less
@@ -266,3 +266,8 @@ h1 > [src$='diskusage48.png'] {
 .icon-xlg {
   .icon(@size-xl);
 }
+
+/* build time trend overrides */
+#trend [src*='/images/16x16/'] {
+  .icon(@size-sm);
+}


### PR DESCRIPTION
Could probably use a selector like the one this commit adds to override the icons properly everywhere?

```
[src$='/images/16x16/blue.png'], [src$='/images/16x16/blue_anime.gif'] {
  .icon(@size-sm);
  ...
}
```