### PR TITLE
Use monospace font instead of Courier New

### DIFF
--- a/less/style.less
+++ b/less/style.less
@@ -220,7 +220,7 @@ table.progress-bar {
 
 .console-output, .console-output *, .CodeMirror {
   position: relative;
-  font-family: "Courier New", Courier, monospace !important;
+  font-family: monospace !important;
   font-size: 14px;
   background: @color-black;
   color: @color-white;
@@ -228,12 +228,12 @@ table.progress-bar {
 }
 
 .CodeMirror pre {
-  font-family: "Courier New", Courier, monospace !important;
+  font-family: monospace !important;
   line-height: 20px !important;
   .cm-builtin {
     color: @color-green !important;
     font-weight: bold;
-    font-family: "Courier New", Courier, monospace !important;
+    font-family: monospace !important;
   }
 }
 


### PR DESCRIPTION
Currently this theme hard-codes Courier New as the monospace font. Since I changed the monospaced font in my browser to one I like more, I would like this theme to use that instead ;)

This should result in no change for Windows users, as Courier New is the same as monospace there.

For Linux users this should improve readability, since Courier New and especially Courier don't render that nicely there.