### PR TITLE
Support longer build history display names

### DIFF
--- a/less/style.less
+++ b/less/style.less
@@ -268,3 +268,15 @@ pre {
     }
   }
 }
+
+.build-row-cell .pane {
+ .build-controls {
+    width: 25%!important;
+  }
+  .build-details {
+    width: 45%!important;
+  }
+  .build-name .display-name { 
+    margin-left: 35%!important;
+  }
+} 


### PR DESCRIPTION
This increases the margin between the build status icon and the display name. It borrows 5% of width from the `.build-details` div so they're further apart and can support longer build number names.