### PR TITLE
Fix issue #97

### DIFF
--- a/less/style.less
+++ b/less/style.less
@@ -2,6 +2,7 @@
 @import '../node_modules/jenkins-core-theme/less/images';
 @import '../node_modules/jenkins-core-theme/less/codemirror';
 @import 'variables';
+@import 'widgets';
 @import url(https://fonts.googleapis.com/css?family=Roboto:400,700,500,300);
 @import url(https://fonts.googleapis.com/css?family=Roboto+Mono:400,700,500,300);
 

--- a/less/widgets.less
+++ b/less/widgets.less
@@ -1,0 +1,4 @@
+/* Build-monitor view widget */
+.build-monitor #widgets li a {
+  line-height: initial;
+}


### PR DESCRIPTION
@i8ramin I don't know why either, but I've fixed it adding a _widget.less_ file where any of these widgets related  fixes/exceptions can be added. What do you think about it @afonsof ?
In this specific case, my solutions was add a property to fix the monitor-view widget.
```css
line-height: initial
```
@afonsof 