### PR TITLE
Update style.less

### DIFF
--- a/less/style.less
+++ b/less/style.less
@@ -30,25 +30,6 @@ a, a:hover, a:visited, a:link {
   }
 }
 
-.task-link[href='/'] {
-  display: none;
-}
-
-.task-icon-link[href='/'] {
-  position: absolute;
-  top: 0;
-  left: 0;
-  background-color: @color-link;
-  height: 64px;
-  width: 250px;
-  z-index: 3000;
-  padding: 12px;
-
-  &:hover {
-    opacity: 1 !important;
-  }
-}
-
 #header {
   .shadow1();
   height: 64px;


### PR DESCRIPTION
Fix issue #141
Removes the href matching for the up/back icon.

When Jenkins is served from the root of a web server, reverts the 'Back to Dashboard' icon and text position to the equivalent location in the default theme.