### PR TITLE
Added Media Queries for Mobile Scaling

### DIFF
--- a/less/style.less
+++ b/less/style.less
@@ -149,6 +149,16 @@ th.pane {
   }
 }
 
+@media all and (max-width: 576px) {
+  #projectstatus th:nth-last-child(-n+5) {
+    display: none;
+  }
+
+  #projectstatus td:nth-last-child(-n+5) {
+    display: none;
+  }
+}
+
 #projectstatus .healthReportDetails table tbody tr td {
     background-color: @color-white !important;
     color: @color-text !important;


### PR DESCRIPTION
I noticed that when viewing on mobile, the table extends past the screen. I added a few media queries that follow [Bootstraps](https://getbootstrap.com/docs/4.2/layout/grid/#grid-options) idea of a small screen to remove the excess table elements. I included some photos below so you can see the difference.

![before1](https://user-images.githubusercontent.com/16086309/52312891-5593a880-297a-11e9-9b81-2d6472aea584.png)
![before2](https://user-images.githubusercontent.com/16086309/52312895-59bfc600-297a-11e9-855d-0bff75f1eba8.png)
![after](https://user-images.githubusercontent.com/16086309/52312900-5c222000-297a-11e9-846b-a1d90bc13a64.png)

