### PR TITLE
Fix overlapping searchbox icon / placeholder

### DIFF
--- a/less/style.less
+++ b/less/style.less
@@ -72,7 +72,6 @@ a, a:hover, a:visited, a:link {
 
   #search-box {
     background: @color-bg;
-    padding-left: 10px;
   }
 }
 


### PR DESCRIPTION
With the latest Jenkins version (2.235), the searchbox icon and placeholder are overlapping.

I checked in Chrome and Firefox:
![image](https://user-images.githubusercontent.com/2586047/81149363-5bfa4100-8f7e-11ea-9652-0bf3e73ee36a.png)

I removed the padding in the css and then it looks ok.